### PR TITLE
[Feat/#10]: 캘린더 API 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,9 +20,11 @@ app.listen(port, () => {
 const userRouter = require("./routes/usersRouter");
 const roomRouter = require("./routes/roomsRouter");
 const memberRouter = require("./routes/membersRouter");
+const scheduleRouter = require("./routes/shedulesRouter");
 
 app.use("/users", userRouter);
 app.use("/rooms", roomRouter);
 app.use("/members", memberRouter);
+app.use("/schedules", scheduleRouter);
 
 module.exports = app;

--- a/controllers/schedulesController.js
+++ b/controllers/schedulesController.js
@@ -1,0 +1,62 @@
+const scheduleService = require("../services/scheduleService");
+const { StatusCodes } = require("http-status-codes");
+
+// 일정 등록
+const createSchedule = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const { roomId } = req.params;
+    const { title, date, time, isAttendance } = req.body;
+
+    const result = await scheduleService.createSchedule(
+      userId,
+      roomId,
+      title,
+      date,
+      time,
+      isAttendance
+    );
+
+    res.status(StatusCodes.CREATED).json(result);
+  } catch (err) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: err.message,
+    });
+  }
+};
+
+// 일정 삭제
+const deleteSchedule = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const { scheduleId } = req.params;
+    const result = await scheduleService.deleteSchedule(userId, scheduleId);
+
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: err.message,
+    });
+  }
+};
+
+// 일정 조회
+const getSchedule = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const { scheduleId } = req.params;
+    const result = await scheduleService.getSchedule(userId, scheduleId);
+
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: err.message,
+    });
+  }
+};
+
+module.exports = {
+  createSchedule,
+  deleteSchedule,
+  getSchedule,
+};

--- a/queries/scheduleQueries.js
+++ b/queries/scheduleQueries.js
@@ -1,0 +1,8 @@
+const scheduleQueries = {
+  createSchedule: `INSERT INTO schedules (id, room_id, title, date, is_attendance) VALUES (?,?,?,?,?)`,
+  deleteSchedule: `DELETE FROM schedules WHERE id = ?`,
+  getSchedule: `SELECT * FROM schedules WHERE id = ?`,
+  getMemberByUserIdRoomId: `SELECT * FROM members WHERE user_id = ? AND room_id = ?`,
+};
+
+module.exports = scheduleQueries;

--- a/routes/membersRouter.js
+++ b/routes/membersRouter.js
@@ -4,7 +4,7 @@ const { createMember } = require("../controllers/membersController");
 
 const memberRouter = express.Router();
 
-memberRouter.post("/:roomCode", verifyToken, createMember);
+memberRouter.post("/:roomCode", verifyToken, createMember); // 멤버로 방 입장하기
 //memberRouter.delete("/:roomId", verifyToken);
 
 module.exports = memberRouter;

--- a/routes/roomsRouter.js
+++ b/routes/roomsRouter.js
@@ -10,8 +10,8 @@ const {
 const roomRouter = express.Router();
 
 roomRouter.post("/", verifyToken, createRoom); // 방 생성
-roomRouter.get("/:roomCode", verifyToken, getRoomByCode);
-roomRouter.get("/", verifyToken, getRooms);
-roomRouter.put("/:roomId/notice", verifyToken, updateNotice);
+roomRouter.get("/:roomCode", verifyToken, getRoomByCode); // 코드로 방 조회 성공
+roomRouter.get("/", verifyToken, getRooms); // 가입한 방 조회
+roomRouter.put("/:roomId/notice", verifyToken, updateNotice); // 공지 등록
 
 module.exports = roomRouter;

--- a/routes/shedulesRouter.js
+++ b/routes/shedulesRouter.js
@@ -1,0 +1,22 @@
+const express = require("express");
+const scheduleRouter = express.Router();
+const schedulesController = require("../controllers/schedulesController");
+const { verifyToken } = require("../middlewares/auth");
+
+scheduleRouter.post(
+  "/:roomId",
+  verifyToken,
+  schedulesController.createSchedule
+); // 일정 등록
+scheduleRouter.delete(
+  "/:scheduleId",
+  verifyToken,
+  schedulesController.deleteSchedule
+); // 일정 삭제
+scheduleRouter.get(
+  "/:scheduleId",
+  verifyToken,
+  schedulesController.getSchedule
+); // 일정 조회
+
+module.exports = scheduleRouter;

--- a/services/scheduleService.js
+++ b/services/scheduleService.js
@@ -1,0 +1,83 @@
+const conn = require("../utils/db");
+const scheduleQueries = require("../queries/scheduleQueries");
+const { v4: uuidv4 } = require("uuid");
+
+const createSchedule = async (
+  userId,
+  roomId,
+  title,
+  date,
+  time,
+  isAttendance
+) => {
+  try {
+    const userResult = await conn.query(
+      scheduleQueries.getMemberByUserIdRoomId,
+      [userId, roomId]
+    );
+    const userRoom = userResult[0][0];
+
+    if (!userRoom) {
+      throw new Error("해당 스터디에 가입되어 있지 않은 회원입니다.");
+    }
+
+    const scheduleId = uuidv4();
+    const dateTime = new Date(`${date}T${time}`); // 날짜 + 시간
+    const values = [scheduleId, roomId, title, dateTime, isAttendance];
+
+    await conn.query(scheduleQueries.createSchedule, values);
+
+    return {
+      message: "일정 등록 성공",
+      schedule: {
+        scheduleId,
+        roomId,
+        title,
+        date,
+        time,
+        isAttendance,
+      },
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+const deleteSchedule = async (userId, scheduleId) => {
+  try {
+    await conn.query(scheduleQueries.deleteSchedule, [scheduleId, userId]);
+
+    return {
+      message: "일정 삭제 성공",
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+const getSchedule = async (userId, scheduleId) => {
+  try {
+    const schedule = await conn.query(scheduleQueries.getSchedule, [
+      scheduleId,
+      userId,
+    ]);
+    const scheduleData = schedule[0][0];
+
+    if (!scheduleData) {
+      throw new Error("일정을 찾을 수 없습니다");
+    }
+
+    return {
+      message: "일정 조회 성공",
+      schedule: scheduleData,
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+module.exports = {
+  createSchedule,
+  deleteSchedule,
+  getSchedule,
+};


### PR DESCRIPTION
## 📝 작업 내용
> 캘린더(일정) API 구현
- 일정 등록 (일정 제목, 일정 시간, 출석부 생성 여부 포함)
- 일정 삭제
- 일정 조회

## ✔️ 리뷰 요구사항 (선택)
> 일정생성 시, 해당 스터디 방에 가입되어 있는 모든 사용자들이 맘껏 일정을 등록하고 삭제, 조회할 수 있도록 등록한 userId를 따로 DB에 넣어두지 않았습니다.
