### PR TITLE
[Feat/#15] 출석 API 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,10 +21,12 @@ const userRouter = require("./routes/usersRouter");
 const roomRouter = require("./routes/roomsRouter");
 const memberRouter = require("./routes/membersRouter");
 const scheduleRouter = require("./routes/shedulesRouter");
+const attendanceRouter = require("./routes/attendancesRouter");
 
 app.use("/users", userRouter);
 app.use("/rooms", roomRouter);
 app.use("/members", memberRouter);
 app.use("/schedules", scheduleRouter);
+app.use("/attendances", attendanceRouter);
 
 module.exports = app;

--- a/controllers/attendancesController.js
+++ b/controllers/attendancesController.js
@@ -1,0 +1,38 @@
+const { StatusCodes } = require("http-status-codes");
+const attendanceService = require("../services/attendanceService");
+
+const updateAttendanceStatus = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const { attendanceId } = req.params;
+    const result = await attendanceService.updateAttendanceStatus(
+      userId,
+      attendanceId
+    );
+
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+const getUserAttendances = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const roomId = req.roomId;
+    const result = await attendanceService.getUserAttendances(userId, roomId);
+
+    res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+module.exports = {
+  updateAttendanceStatus,
+  getUserAttendances,
+};

--- a/controllers/membersController.js
+++ b/controllers/membersController.js
@@ -5,16 +5,27 @@ const createMember = async (req, res) => {
   try {
     const userId = req.userId;
     const code = req.params.roomCode;
-    const profileNum = await memberService.createMember(userId, code);
+    const result = await memberService.createMember(userId, code);
 
-    return res.status(StatusCodes.CREATED).json({
-      profileNum,
-    });
+    return res.status(StatusCodes.CREATED).json(result);
   } catch (err) {
-    return res.status(StatusCodes.BAD_REQUEST).json({
+    res.status(err.statusCode || 500).json({
       message: err.message,
     });
   }
 };
 
-module.exports = { createMember };
+const getMembersRecord = async (req, res) => {
+  try {
+    const roomId = req.roomId;
+    const result = await memberService.getMembersRecord(roomId);
+
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+module.exports = { createMember, getMembersRecord };

--- a/controllers/roomsController.js
+++ b/controllers/roomsController.js
@@ -74,7 +74,7 @@ const updateNotice = async (req, res) => {
 
     const { notice } = req.body;
 
-    await roomService.updateNotice(userId, roomId, notice);
+    await roomService.updateNotice(roomId, notice);
 
     return res.status(StatusCodes.OK).json({
       notice,

--- a/controllers/schedulesController.js
+++ b/controllers/schedulesController.js
@@ -4,11 +4,16 @@ const { StatusCodes } = require("http-status-codes");
 // 일정 등록
 const createSchedule = async (req, res) => {
   try {
-    const userId = req.userId;
-    const { roomId, title, date, time, isAttendance } = req.body;
+    const roomId = req.roomId;
+    const { title, date, time, isAttendance } = req.body;
+
+    if (!title || !date || !time || !isAttendance) {
+      res.status(StatusCodes.BAD_REQUEST).json({
+        message: "요청값을 확인해주세요",
+      });
+    }
 
     const result = await scheduleService.createSchedule(
-      userId,
       roomId,
       title,
       date,
@@ -28,12 +33,9 @@ const createSchedule = async (req, res) => {
 const deleteSchedule = async (req, res) => {
   try {
     const userId = req.userId;
-    const { roomId, scheduleId } = req.params;
-    const result = await scheduleService.deleteSchedule(
-      userId,
-      roomId,
-      scheduleId
-    );
+
+    const { scheduleId } = req.params;
+    const result = await scheduleService.deleteSchedule(userId, scheduleId);
 
     res.status(StatusCodes.OK).json(result);
   } catch (err) {
@@ -47,8 +49,16 @@ const deleteSchedule = async (req, res) => {
 const getSchedule = async (req, res) => {
   try {
     const userId = req.userId;
-    const { roomId } = req.params;
-    const result = await scheduleService.getSchedule(userId, roomId);
+    const roomId = req.roomId;
+    const { isAttendance } = req.query;
+
+    let result;
+    if (isAttendance) {
+      result = await scheduleService.getAttendanceDate(userId, roomId);
+    } else {
+      result = await scheduleService.getSchedule(roomId);
+    }
+    console.log(result);
 
     res.status(StatusCodes.OK).json(result);
   } catch (err) {

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,6 +1,8 @@
 const jwt = require("jsonwebtoken");
 const { StatusCodes } = require("http-status-codes");
 const { JWT_SECRET } = require("../settings");
+const { checkRoom } = require("../services/roomService");
+const { checkMember } = require("../services/memberService");
 
 const createAccessToken = (userId) => {
   return jwt.sign({ id: userId }, JWT_SECRET, { expiresIn: "1h" });
@@ -27,7 +29,38 @@ const verifyToken = (req, res, next) => {
   });
 };
 
+// 유효한 방인지, 유저가 해당 방의 멤버인지 체크하는 미들웨어
+// 요청 객체에 방 ID 추가 (req.roomId)
+const authorizeUser = async (req, res, next) => {
+  const userId = req.userId;
+  const roomId = req.params.roomId || req.body.roomId;
+
+  if (!roomId) {
+    return res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ message: "스터디방 id가 필요합니다" });
+  }
+
+  const isValidRoomId = await checkRoom(roomId);
+  if (!isValidRoomId) {
+    return res
+      .status(StatusCodes.NOT_FOUND)
+      .json({ message: "존재하지 않는 스터디입니다." });
+  }
+
+  const isValidMember = await checkMember(userId, roomId);
+  if (!isValidMember) {
+    return res
+      .status(StatusCodes.FORBIDDEN)
+      .json({ message: "해당 스터디 멤버가 아닙니다." });
+  }
+
+  req.roomId = roomId;
+  next();
+};
+
 module.exports = {
   createAccessToken,
   verifyToken,
+  authorizeUser,
 };

--- a/queries/attendanceQueries.js
+++ b/queries/attendanceQueries.js
@@ -1,0 +1,25 @@
+const attendanceQueries = {
+  createAttendances: `
+    INSERT 
+    INTO attendances (id, schedule_id, user_id, status)
+    VALUES ?
+    `,
+  deleteAttendances: `
+    DELETE FROM attendances WHERE schedule_id = ?
+  `,
+  updateAttendanceStatus: `
+    UPDATE attendances
+    SET status = 1
+    WHERE id = ? AND user_id = ?
+  `,
+  getUserAttendances: `
+    SELECT status, date
+    FROM attendances
+    JOIN schedules
+    ON schedules.id = attendances.schedule_id
+    WHERE attendances.user_id = ? AND schedules.room_id = ?
+    ORDER BY date DESC
+  `,
+};
+
+module.exports = attendanceQueries;

--- a/queries/memberQueries.js
+++ b/queries/memberQueries.js
@@ -6,6 +6,25 @@ const memberQueries = {
     FROM members
     WHERE members.room_id = ? AND members.user_id = ?
   `,
+  getMembers: `
+    SELECT * FROM members WHERE room_id = ?
+  `,
+  getMembersName: `
+    SELECT name
+    FROM users
+    JOIN members
+    ON users.id = members.user_id
+    ORDER BY name
+  `,
+  getMembersAttendanceCount: `
+    SELECT users.name, COUNT(attendances.id) AS count
+    FROM users
+    JOIN members ON users.id = members.user_id
+    LEFT JOIN attendances ON users.id = attendances.user_id AND attendances.status = 1
+    LEFT JOIN schedules ON schedules.id = attendances.schedule_id 
+    WHERE members.room_id = ?
+    GROUP BY users.id;
+  `,
 };
 
 module.exports = memberQueries;

--- a/queries/roomQueries.js
+++ b/queries/roomQueries.js
@@ -26,6 +26,11 @@ const roomQueries = {
     SET notice = ?
     WHERE id = ?
   `,
+  checkRoomId: `
+    SELECT COUNT(*) AS count
+    FROM rooms
+    WHERE id = ?
+  `,
 };
 
 module.exports = roomQueries;

--- a/queries/scheduleQueries.js
+++ b/queries/scheduleQueries.js
@@ -3,7 +3,19 @@ const scheduleQueries = {
   deleteSchedule: `DELETE FROM schedules WHERE id = ?`,
   getSchedule: `SELECT * FROM schedules WHERE id = ?`,
   getSchedulesByRoomId: `SELECT * FROM schedules WHERE room_id = ?`,
-  getMemberByUserIdRoomId: `SELECT * FROM members WHERE user_id = ? AND room_id = ?`,
+  getAttendanceDate: `
+    SELECT attendances.id as attendanceId, title, date
+    FROM attendances
+    JOIN schedules
+    ON attendances.schedule_id = schedules.id
+    WHERE schedules.room_id = ? AND addtime(schedules.date, "0:20:0") > NOW() AND attendances.user_id = ?
+    ORDER BY date ASC LIMIT 1
+  `,
+  getTotalAttendances: `
+    SELECT COUNT(*) AS totalCount
+    FROM schedules
+    WHERE room_id = ? AND is_attendance=1
+  `,
 };
 
 module.exports = scheduleQueries;

--- a/routes/attendancesRouter.js
+++ b/routes/attendancesRouter.js
@@ -1,0 +1,23 @@
+const express = require("express");
+const attendanceRouter = express.Router();
+const { verifyToken, authorizeUser } = require("../middlewares/auth");
+const {
+  updateAttendanceStatus,
+  getUserAttendances,
+} = require("../controllers/attendancesController");
+
+attendanceRouter.put(
+  "/:attendanceId",
+  verifyToken,
+  authorizeUser,
+  updateAttendanceStatus
+);
+
+attendanceRouter.get(
+  "/:roomId",
+  verifyToken,
+  authorizeUser,
+  getUserAttendances
+);
+
+module.exports = attendanceRouter;

--- a/routes/membersRouter.js
+++ b/routes/membersRouter.js
@@ -1,10 +1,14 @@
 const express = require("express");
-const { verifyToken } = require("../middlewares/auth");
-const { createMember } = require("../controllers/membersController");
+const { verifyToken, authorizeUser } = require("../middlewares/auth");
+const {
+  createMember,
+  getMembersRecord,
+} = require("../controllers/membersController");
 
 const memberRouter = express.Router();
 
 memberRouter.post("/:roomCode", verifyToken, createMember); // 멤버로 방 입장하기
-//memberRouter.delete("/:roomId", verifyToken);
+//memberRouter.delete("/:roomId", verifyToken, authorizeUser);
+memberRouter.get("/:roomId", verifyToken, authorizeUser, getMembersRecord);
 
 module.exports = memberRouter;

--- a/routes/roomsRouter.js
+++ b/routes/roomsRouter.js
@@ -3,7 +3,6 @@ const { verifyToken } = require("../middlewares/auth");
 const {
   createRoom,
   getRoomByCode,
-  createMember,
   getRooms,
   updateNotice,
 } = require("../controllers/roomsController");

--- a/routes/shedulesRouter.js
+++ b/routes/shedulesRouter.js
@@ -1,14 +1,27 @@
 const express = require("express");
 const scheduleRouter = express.Router();
 const schedulesController = require("../controllers/schedulesController");
-const { verifyToken } = require("../middlewares/auth");
+const { verifyToken, authorizeUser } = require("../middlewares/auth");
 
-scheduleRouter.post("/", verifyToken, schedulesController.createSchedule); // 일정 등록
+scheduleRouter.post(
+  "/",
+  verifyToken,
+  authorizeUser,
+  schedulesController.createSchedule
+); // 일정 등록
+
 scheduleRouter.delete(
   "/:roomId/:scheduleId",
   verifyToken,
+  authorizeUser,
   schedulesController.deleteSchedule
 ); // 일정 삭제
-scheduleRouter.get("/:roomId", verifyToken, schedulesController.getSchedule); // 일정 조회
+
+scheduleRouter.get(
+  "/:roomId",
+  verifyToken,
+  authorizeUser,
+  schedulesController.getSchedule
+); // 일정(출석날짜) 조회
 
 module.exports = scheduleRouter;

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -1,0 +1,79 @@
+const conn = require("../utils/db");
+const attendanceQueries = require("../queries/attendanceQueries");
+const { v4: uuidv4 } = require("uuid");
+const CustomError = require("../utils/CustomError");
+const { StatusCodes } = require("http-status-codes");
+
+const createAttendance = async (scheduleId, members) => {
+  try {
+    const values = members.map((memberId) => [
+      uuidv4(),
+      scheduleId,
+      memberId,
+      false,
+    ]);
+
+    return await conn.query(attendanceQueries.createAttendances, [values]);
+  } catch (err) {
+    throw err;
+  }
+};
+
+const deleteAttendances = async (scheduleId) => {
+  try {
+    return await conn.query(attendanceQueries.deleteAttendances, scheduleId);
+  } catch (err) {
+    throw err;
+  }
+};
+
+const updateAttendanceStatus = async (userId, attendanceId) => {
+  try {
+    const [updateResult] = await conn.query(
+      attendanceQueries.updateAttendanceStatus,
+      [attendanceId, userId]
+    );
+
+    if (updateResult.affectedRows === 0) {
+      throw new CustomError(
+        "존재하지 않는 일정입니다.",
+        StatusCodes.BAD_REQUEST
+      );
+    }
+
+    return {
+      message: "출석 성공",
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+const getUserAttendances = async (userId, roomId) => {
+  try {
+    const [attendanceResult] = await conn.query(
+      attendanceQueries.getUserAttendances,
+      [userId, roomId]
+    );
+
+    const records = attendanceResult.map((record) => ({
+      date: record.date.split(" ")[0],
+      time: record.date.split(" ")[1],
+      status: record.status,
+    }));
+
+    return {
+      message: "출석 조회 성공",
+      records,
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+module.exports = {
+  createAttendance,
+  deleteAttendances,
+  updateAttendanceStatus,
+  getUserAttendances,
+};

--- a/services/memberService.js
+++ b/services/memberService.js
@@ -2,40 +2,97 @@ const conn = require("../utils/db");
 const memberQueries = require("../queries/memberQueries");
 const roomQueries = require("../queries/roomQueries");
 const roomService = require("./roomService");
+const CustomError = require("../utils/CustomError");
+const { StatusCodes } = require("http-status-codes");
+const scheduleQueries = require("../queries/scheduleQueries");
 
 const createMember = async (userId, code) => {
   try {
     const room = await roomService.getRoomByCode(code);
     const count = await checkMember(userId, room.roomId);
     if (count != 0) {
-      throw new Error("이미 가입된 스터디입니다.");
+      throw new CustomError(
+        "이미 가입된 스터디입니다.",
+        StatusCodes.BAD_REQUEST
+      );
     }
 
     if (room.member_count >= 8) {
-      throw new Error("제한 인원을 초과하여 가입할 수 없는 스터디입니다.");
+      throw new CustomError(
+        "제한 인원을 초과하여 가입할 수 없는 스터디입니다.",
+        StatusCodes.FORBIDDEN
+      );
     }
 
     const values = [userId, room.roomId, room.member_count + 1];
 
-    await conn.query(memberQueries.createMember, values);
+    const [memberResult] = await conn.query(memberQueries.createMember, values);
+    if (memberResult.affectedRows === 0) {
+      throw new CustomError("스터디 가입 실패", StatusCodes.BAD_REQUEST);
+    }
+
     await conn.query(roomQueries.updateRoomMemberCount, room.roomId);
 
-    return room.member_count + 1;
+    return {
+      profileNum: room.member_count + 1,
+    };
   } catch (err) {
     throw err;
   }
 };
 
 const checkMember = async (userId, roomId) => {
-  const [[{ count }]] = await conn.query(memberQueries.checkMember, [
-    roomId,
-    userId,
-  ]);
+  try {
+    const [[{ count }]] = await conn.query(memberQueries.checkMember, [
+      roomId,
+      userId,
+    ]);
 
-  return count;
+    return count;
+  } catch (err) {
+    throw err;
+  }
+};
+
+const getMembersRecord = async (roomId) => {
+  try {
+    const [[{ totalCount }]] = await conn.query(
+      scheduleQueries.getTotalAttendances,
+      roomId
+    );
+
+    if (totalCount === 0) {
+      const [memberResult] = await conn.query(
+        memberQueries.getMembersName,
+        roomId
+      );
+
+      return {
+        members: memberResult.map((member) => ({
+          name: member.name,
+          attendanceRate: 100,
+        })),
+      };
+    }
+
+    const [memberResult] = await conn.query(
+      memberQueries.getMembersAttendanceCount,
+      [roomId]
+    );
+
+    return {
+      members: memberResult.map((member) => ({
+        name: member.name,
+        attendanceRate: Math.round((member.count * 100) / totalCount),
+      })),
+    };
+  } catch (err) {
+    throw err;
+  }
 };
 
 module.exports = {
   createMember,
   checkMember,
+  getMembersRecord,
 };


### PR DESCRIPTION
## 📝 작업 내용
### 출석 관련 기능 구현
- 일정 등록, 삭제 시 출석부도 함께 등록, 삭제되도록 함.
- 출석하기
- 개인 출석 내역 조회
- 다음 출석 날짜 조회
- 스터디 방 멤버 출석률 조회

### authorizeUser 미들웨어
- params 혹은 body로 보낸 roomId가 유효한지 검사 (유효하지 않다면 400)
- 방에 관련된 api를 호출한 유저가 해당 방의 member인지 검사 (member가 아니면 403)
- req 객체에 roomId 추가

## ✔️ 리뷰 요구사항 (선택)
<img width="521" alt="image" src="https://github.com/user-attachments/assets/99197e6b-628e-4cca-bdfc-e89c7a6cc61e">

정상적인 케이스에서 잘 동작하는지, 에러 처리 잘 됐는지 확인 부탁드려요...!