### PR TITLE
[Feat/#27] 노트 API 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,6 +59,8 @@ const memberRouter = require("./routes/membersRouter");
 const scheduleRouter = require("./routes/shedulesRouter");
 const chatRouter = require("./routes/chatsRouter");
 const attendanceRouter = require("./routes/attendancesRouter");
+const noteRouter = require("./routes/notesRouter");
+const tagRouter = require("./routes/tagsRouter");
 
 app.use("/users", userRouter);
 app.use("/rooms", roomRouter);
@@ -66,5 +68,7 @@ app.use("/members", memberRouter);
 app.use("/schedules", scheduleRouter);
 app.use("/chats", chatRouter);
 app.use("/attendances", attendanceRouter);
+app.use("/notes", noteRouter);
+app.use("/tags", tagRouter);
 
 module.exports = app;

--- a/controllers/notesController.js
+++ b/controllers/notesController.js
@@ -1,0 +1,72 @@
+const { StatusCodes } = require("http-status-codes");
+const noteService = require("../services/noteService");
+const CustomError = require("../utils/CustomError");
+
+const createNote = async (req, res) => {
+  try {
+    const roomId = req.roomId;
+    const { title, content, tags } = req.body;
+
+    const result = await noteService.createNote(roomId, title, content, tags);
+    return res.status(StatusCodes.CREATED).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+const getNotes = async (req, res) => {
+  try {
+    const roomId = req.roomId;
+    let { tag, limit, currentPage } = req.query;
+    limit = parseInt(limit);
+    currentPage = parseInt(currentPage);
+    const tags = tag?.split(",") || [];
+
+    if (!limit || !currentPage) {
+      return res.status(StatusCodes.BAD_REQUEST).json({
+        message: "잘못된 url 형식입니다.",
+      });
+    }
+
+    const result = await noteService.getNotes(roomId, tags, limit, currentPage);
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+const updateNote = async (req, res) => {
+  try {
+    const { noteId } = req.params;
+    let { title, content, tags } = req.body;
+    if (!title || !content || !tags) {
+      throw new CustomError("요청값을 확인해주세요", StatusCodes.BAD_REQUEST);
+    }
+
+    const result = await noteService.updateNote(noteId, title, content, tags);
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+const deleteNote = async (req, res) => {
+  try {
+    const { noteId } = req.params;
+
+    const result = await noteService.deleteNote(noteId);
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+module.exports = { createNote, getNotes, updateNote, deleteNote };

--- a/controllers/tagsController.js
+++ b/controllers/tagsController.js
@@ -1,0 +1,16 @@
+const { StatusCodes } = require("http-status-codes");
+const tagService = require("../services/tagService");
+
+const getTags = async (req, res) => {
+  try {
+    const roomId = req.roomId;
+    const result = await tagService.getTags(roomId);
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
+module.exports = { getTags };

--- a/queries/noteQueries.js
+++ b/queries/noteQueries.js
@@ -1,0 +1,45 @@
+const noteQueries = {
+  createNote: `
+    INSERT INTO notes (id, room_id, title, content) VALUES (?, ?, ?, ?)
+  `,
+  getNotesFilteredByTags: `
+    SELECT notes.id AS noteId, title, content, created_at AS createdAt
+    FROM notes
+    LEFT JOIN tags
+    ON tags.note_id = notes.id
+    WHERE notes.room_id = ? AND tags.name IN ?
+    GROUP BY notes.id
+    ORDER BY notes.created_at DESC
+    LIMIT ? OFFSET ?
+  `,
+  getCountFilteredByTags: `
+    SELECT COUNT(DISTINCT notes.id) AS totalCount
+    FROM notes
+    LEFT JOIN tags
+    ON tags.note_id = notes.id
+    WHERE notes.room_id = ? AND tags.name IN ?
+  `,
+  getNotes: `
+    SELECT id AS noteId, title, content, created_at as createdAt
+    FROM notes
+    WHERE room_id = ?
+    ORDER BY notes.created_at DESC
+    LIMIT ? OFFSET ?
+  `,
+  getCount: `
+    SELECT COUNT(*) AS totalCount FROM notes WHERE room_id = ?
+  `,
+  getNote: `
+    SELECT * FROM notes where id = ?;
+  `,
+  updateNote: `
+    UPDATE notes
+    SET title = ?, content = ?
+    WHERE id = ?
+  `,
+  deleteNote: `
+    DELETE FROM notes WHERE id = ?
+  `,
+};
+
+module.exports = noteQueries;

--- a/queries/tagQueries.js
+++ b/queries/tagQueries.js
@@ -1,0 +1,22 @@
+const tagQueries = {
+  createTag: `
+    INSERT INTO tags (id, room_id, note_id, name) VALUES ?
+  `,
+  deleteTag: `
+    DELETE FROM tags WHERE note_id = ? AND name = ?
+  `,
+  getTagsByNote: `
+    SELECT name
+    FROM tags
+    WHERE note_id = ?
+  `,
+  getTagsByRoom: `
+    SELECT name
+    FROM tags
+    WHERE room_id = ?
+    GROUP BY name
+    ORDER BY name ASC
+  `,
+};
+
+module.exports = tagQueries;

--- a/routes/notesRouter.js
+++ b/routes/notesRouter.js
@@ -1,0 +1,16 @@
+const express = require("express");
+const { verifyToken, authorizeUser } = require("../middlewares/auth");
+const {
+  createNote,
+  getNotes,
+  updateNote,
+  deleteNote,
+} = require("../controllers/notesController");
+
+const noteRouter = express.Router();
+
+noteRouter.post("/:roomId", verifyToken, authorizeUser, createNote);
+noteRouter.get("/:roomId", verifyToken, authorizeUser, getNotes);
+noteRouter.put("/:noteId", verifyToken, authorizeUser, updateNote);
+noteRouter.delete("/:roomId/:noteId", verifyToken, authorizeUser, deleteNote);
+module.exports = noteRouter;

--- a/routes/tagsRouter.js
+++ b/routes/tagsRouter.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const { verifyToken, authorizeUser } = require("../middlewares/auth");
+const { getTags } = require("../controllers/tagsController");
+
+const tagRouter = express.Router();
+
+tagRouter.get("/:roomId", verifyToken, authorizeUser, getTags);
+
+module.exports = tagRouter;

--- a/services/noteService.js
+++ b/services/noteService.js
@@ -1,0 +1,174 @@
+const conn = require("../utils/db");
+const { StatusCodes } = require("http-status-codes");
+const { v4: uuidv4 } = require("uuid");
+const noteQueries = require("../queries/noteQueries");
+const CustomError = require("../utils/CustomError");
+const tagQueries = require("../queries/tagQueries");
+
+const addNote = async (roomId, title, content) => {
+  try {
+    const noteId = uuidv4();
+    const values = [noteId, roomId, title, content];
+    const [result] = await conn.query(noteQueries.createNote, values);
+
+    if (result.affectedRows === 0) {
+      throw new CustomError("노트 생성 실패", StatusCodes.BAD_REQUEST);
+    }
+
+    return noteId;
+  } catch (err) {
+    throw err;
+  }
+};
+
+const addTags = async (roomId, noteId, tags) => {
+  try {
+    const values = tags.map((tag) => [uuidv4(), roomId, noteId, tag]);
+    const [result] = await conn.query(tagQueries.createTag, [values]);
+
+    if (result.affectedRows === 0) {
+      throw new CustomError("태그 생성 실패", StatusCodes.BAD_REQUEST);
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
+const getTagsByNote = async (noteId) => {
+  try {
+    const [result] = await conn.query(tagQueries.getTagsByNote, noteId);
+
+    return result.map(({ name }) => name);
+  } catch (err) {
+    throw err;
+  }
+};
+
+const updateNoteContent = async (noteId, title, content) => {
+  try {
+    const [updateResult] = await conn.query(noteQueries.updateNote, [
+      title,
+      content,
+      noteId,
+    ]);
+
+    if (updateResult.affectedRows === 0) {
+      throw new CustomError("노트 수정 실패", StatusCodes.BAD_REQUEST);
+    }
+  } catch (err) {
+    throw err;
+  }
+};
+
+const updateNoteTags = async (noteId, roomId, tags) => {
+  const [getTagsResult] = await conn.query(tagQueries.getTagsByNote, noteId);
+  const existingTags = getTagsResult.map((tag) => tag.name);
+
+  const deleteList = existingTags.filter((tag) => !tags.includes(tag));
+  const addList = tags
+    .filter((tag) => !existingTags.includes(tag))
+    .map((name) => [uuidv4(), roomId, noteId, name]);
+
+  for (let name of deleteList) {
+    await conn.query(tagQueries.deleteTag, [noteId, name]);
+  }
+
+  if (addList.length) {
+    await conn.query(tagQueries.createTag, [addList]);
+  }
+};
+
+const checkNote = async (noteId) => {
+  try {
+    const [[note]] = await conn.query(noteQueries.getNote, noteId);
+    if (!note) {
+      throw new CustomError("존재하지 않는 노트입니다", StatusCodes.NOT_FOUND);
+    }
+
+    return note;
+  } catch (err) {
+    throw err;
+  }
+};
+
+const createNote = async (roomId, title, content, tags) => {
+  try {
+    const noteId = await addNote(roomId, title, content);
+    await addTags(roomId, noteId, tags);
+
+    return {
+      message: "노트 등록 성공",
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+const getNotes = async (roomId, tags, limit, currentPage) => {
+  const offset = (currentPage - 1) * limit;
+
+  const [[{ totalCount }]] = tags.length
+    ? await conn.query(noteQueries.getCountFilteredByTags, [roomId, [tags]])
+    : await conn.query(noteQueries.getCount, roomId);
+
+  const [getNotesResult] = tags.length
+    ? await conn.query(noteQueries.getNotesFilteredByTags, [
+        roomId,
+        [tags],
+        limit,
+        offset,
+      ])
+    : await conn.query(noteQueries.getNotes, [roomId, limit, offset]);
+
+  if (getNotesResult.length === 0) {
+    throw new CustomError("노트 조회 실패", StatusCodes.NOT_FOUND);
+  }
+
+  const notes = [];
+  for (let note of getNotesResult) {
+    const tagsResult = await getTagsByNote(note.noteId);
+    notes.push({ ...note, tags: tagsResult });
+  }
+
+  return {
+    message: "노트 조회 성공",
+    notes,
+    pagination: {
+      currentPage,
+      totalCount,
+    },
+  };
+};
+
+const updateNote = async (noteId, title, content, tags) => {
+  try {
+    const note = await checkNote(noteId);
+    await updateNoteContent(noteId, title, content);
+    await updateNoteTags(noteId, note.room_id, tags);
+
+    return {
+      message: "노트 수정 성공",
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+const deleteNote = async (noteId) => {
+  try {
+    await checkNote(noteId);
+
+    const [deleteResult] = await conn.query(noteQueries.deleteNote, noteId);
+
+    if (deleteResult.affectedRows === 0)
+      throw new CustomError("노트 삭제 실패", StatusCodes.BAD_REQUEST);
+
+    return {
+      message: "노트 삭제 성공",
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
+module.exports = { createNote, getNotes, updateNote, deleteNote };

--- a/services/tagService.js
+++ b/services/tagService.js
@@ -1,0 +1,13 @@
+const tagQueries = require("../queries/tagQueries");
+const conn = require("../utils/db");
+
+const getTags = async (roomId) => {
+  const [result] = await conn.query(tagQueries.getTagsByRoom, roomId);
+
+  return {
+    message: "태그 조회 성공",
+    tags: result.map(({ name }) => name),
+  };
+};
+
+module.exports = { getTags };


### PR DESCRIPTION
## 📝 작업 내용
### 노트 API 구현
- 노트 등록 API (태그도 함께 등록)
- 노트 수정 API (태그도 함께 수정)
- 노트 삭제 API
- 노트 목록 조회 API
  - 최신 작성 순으로 반환
  - 태그 필터링 : 선택한 태그 중 하나라도 포함된 노트 반환
  - 페이지네이션
- 태그 목록 조회 API
  - 방에 존재하는 태그 중복 없이 오름차순 정렬로 반환

## ✔️ 리뷰 요구사항 (선택)
- 목록 조회할 때 필터링, 페이지네이션이 잘 동작하는지 점검 부탁드립니다!
