### PR TITLE
[Fix/#31] 전체 API 수정

### DIFF
--- a/controllers/attendancesController.js
+++ b/controllers/attendancesController.js
@@ -1,10 +1,14 @@
 const { StatusCodes } = require("http-status-codes");
 const attendanceService = require("../services/attendanceService");
+const CustomError = require("../utils/CustomError");
 
 const updateAttendanceStatus = async (req, res) => {
   try {
     const userId = req.userId;
-    const { attendanceId } = req.params;
+    const { attendanceId } = req.body;
+    if (!attendanceId) {
+      throw new CustomError("출석 id가 필요합니다", StatusCodes.BAD_REQUEST);
+    }
     const result = await attendanceService.updateAttendanceStatus(
       userId,
       attendanceId

--- a/controllers/linksController.js
+++ b/controllers/linksController.js
@@ -5,7 +5,7 @@ const { StatusCodes } = require("http-status-codes");
 const createLink = async (req, res) => {
   try {
     const userId = req.userId;
-    const { roomId } = req.params;
+    const roomId = req.roomId;
     const { title, link } = req.body;
 
     const result = await linkService.createLink(roomId, userId, title, link);
@@ -21,10 +21,9 @@ const createLink = async (req, res) => {
 // 자료 조회
 const getLinks = async (req, res) => {
   try {
-    const userId = req.userId;
-    const { roomId } = req.params;
+    const roomId = req.roomId;
 
-    const result = await linkService.getLinks(roomId, userId);
+    const result = await linkService.getLinks(roomId);
 
     res.status(StatusCodes.OK).json(result);
   } catch (err) {
@@ -37,10 +36,9 @@ const getLinks = async (req, res) => {
 // 자료 삭제
 const deleteLink = async (req, res) => {
   try {
-    const userId = req.userId;
     const { linkId } = req.params;
 
-    const result = await linkService.deleteLink(linkId, userId);
+    const result = await linkService.deleteLink(linkId);
     res.status(StatusCodes.OK).json(result);
   } catch (err) {
     res.status(err.statusCode || 500).json({

--- a/controllers/notesController.js
+++ b/controllers/notesController.js
@@ -39,6 +39,19 @@ const getNotes = async (req, res) => {
   }
 };
 
+const getNoteContent = async (req, res) => {
+  try {
+    const { noteId } = req.params;
+    const result = await noteService.getNoteContent(noteId);
+
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
 const updateNote = async (req, res) => {
   try {
     const { noteId } = req.params;
@@ -69,4 +82,10 @@ const deleteNote = async (req, res) => {
   }
 };
 
-module.exports = { createNote, getNotes, updateNote, deleteNote };
+module.exports = {
+  createNote,
+  getNotes,
+  updateNote,
+  deleteNote,
+  getNoteContent,
+};

--- a/controllers/roomsController.js
+++ b/controllers/roomsController.js
@@ -7,9 +7,9 @@ const createRoom = async (req, res) => {
     const userId = req.userId;
     const { title } = req.body;
 
-    if (!title) {
+    if (title === undefined || title.length > 10) {
       throw new CustomError(
-        "스터디 이름이 필요합니다",
+        "스터디 이름이 없거나 10자보다 깁니다",
         StatusCodes.BAD_REQUEST
       );
     }
@@ -17,20 +17,6 @@ const createRoom = async (req, res) => {
     const result = await roomService.createRoom(userId, title);
 
     res.status(StatusCodes.CREATED).json(result);
-  } catch (err) {
-    res.status(err.statusCode || 500).json({
-      message: err.message,
-    });
-  }
-};
-
-const getRoomByCode = async (req, res) => {
-  try {
-    const code = req.params.roomCode;
-
-    const result = await roomService.getRoomByCode(code);
-
-    return res.status(StatusCodes.OK).json(result);
   } catch (err) {
     res.status(err.statusCode || 500).json({
       message: err.message,
@@ -66,9 +52,23 @@ const updateNotice = async (req, res) => {
   }
 };
 
+const getRoom = async (req, res) => {
+  try {
+    const userId = req.userId;
+    const roomId = req.roomId;
+    const result = await roomService.getRoom(roomId, userId);
+
+    return res.status(StatusCodes.OK).json(result);
+  } catch (err) {
+    res.status(err.statusCode || 500).json({
+      message: err.message,
+    });
+  }
+};
+
 module.exports = {
   createRoom,
-  getRoomByCode,
   getRooms,
   updateNotice,
+  getRoom,
 };

--- a/controllers/schedulesController.js
+++ b/controllers/schedulesController.js
@@ -7,7 +7,7 @@ const createSchedule = async (req, res) => {
     const roomId = req.roomId;
     const { title, date, time, isAttendance } = req.body;
 
-    if (!title || !date || !time || !isAttendance) {
+    if (!title || !date || !time || isAttendance === undefined) {
       res.status(StatusCodes.BAD_REQUEST).json({
         message: "요청값을 확인해주세요",
       });
@@ -33,9 +33,10 @@ const createSchedule = async (req, res) => {
 const deleteSchedule = async (req, res) => {
   try {
     const userId = req.userId;
+    const roomId = req.roomId;
 
     const { scheduleId } = req.params;
-    const result = await scheduleService.deleteSchedule(userId, scheduleId);
+    const result = await scheduleService.deleteSchedule(roomId, scheduleId);
 
     res.status(StatusCodes.OK).json(result);
   } catch (err) {

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -21,7 +21,7 @@ const verifyToken = (req, res, next) => {
   jwt.verify(token, JWT_SECRET, (err, decoded) => {
     if (err) {
       return res
-        .status(StatusCodes.FORBIDDEN)
+        .status(StatusCodes.UNAUTHORIZED)
         .json({ message: "유효하지 않은 access token입니다" });
     }
     req.userId = decoded.id; // 토큰에서 사용자 ID를 요청 객체에 추가

--- a/queries/attendanceQueries.js
+++ b/queries/attendanceQueries.js
@@ -24,6 +24,18 @@ const attendanceQueries = {
     DELETE FROM attendances
     WHERE user_id = ? AND schedule_id IN (SELECT id FROM schedules WHERE room_id = ?)
   `,
+  getAttendanceId: `
+    SELECT id
+    FROM attendances
+    WHERE user_id = ? AND schedule_id = ?
+  `,
+  getAttendancesByRoom: `
+    SELECT attendances.id as attendanceId, schedules.id as scheduleId, title, date
+    FROM attendances
+    LEFT JOIN schedules
+    ON schedules.id = attendances.schedule_id
+    WHERE user_id = ? AND room_id = ? AND date > NOW()
+  `,
 };
 
 module.exports = attendanceQueries;

--- a/queries/linkQueries.js
+++ b/queries/linkQueries.js
@@ -2,7 +2,6 @@ const linkQueries = {
   createLink: `INSERT INTO links (id, room_id, title, url) VALUES (?,?,?,?)`,
   getLinks: `SELECT * FROM links WHERE room_id =? ORDER BY created_at DESC`,
   deleteLink: `DELETE FROM links WHERE id =?`,
-  getDate: `SELECT created_at FROM links WHERE id = ?`,
   getLinkById: `SELECT room_id FROM links WHERE id = ?`,
 };
 

--- a/queries/memberQueries.js
+++ b/queries/memberQueries.js
@@ -14,14 +14,19 @@ const memberQueries = {
     JOIN rooms
     ON rooms.id = members.room_id
     WHERE members.room_id = ?
-
   `,
   getMembersName: `
-    SELECT name
+    SELECT name, profile_num
     FROM users
     JOIN members
     ON users.id = members.user_id
+    WHERE members.room_id = ?
     ORDER BY name
+  `,
+  getMembersCount: `
+    SELECT COUNT(*) as memberCount
+    FROM members
+    WHERE room_id = ?
   `,
   getMembersAttendanceCount: `
     SELECT users.name, members.profile_num, COUNT(attendances.id) AS count
@@ -32,19 +37,20 @@ const memberQueries = {
     WHERE members.room_id = ?
     GROUP BY users.id;
   `,
-  getProfiles: `
+  getMembersProfiles: `
     SELECT profile_num
     FROM members
     WHERE room_id = ?
   `,
-
   deleteMember: `
     DELETE FROM members
     WHERE user_id = ? and room_id = ?
   `,
-
   updateAlarm: `
     UPDATE members SET alarm = ? WHERE user_id = ? AND room_id = ?
+  `,
+  getAlarmsOff: `
+    UPDATE members SET alarm = false WHERE user_id = ?
   `,
 };
 

--- a/queries/noteQueries.js
+++ b/queries/noteQueries.js
@@ -3,7 +3,7 @@ const noteQueries = {
     INSERT INTO notes (id, room_id, title, content) VALUES (?, ?, ?, ?)
   `,
   getNotesFilteredByTags: `
-    SELECT notes.id AS noteId, title, content, created_at AS createdAt
+    SELECT notes.id AS noteId, title, created_at AS createdAt
     FROM notes
     LEFT JOIN tags
     ON tags.note_id = notes.id
@@ -20,7 +20,7 @@ const noteQueries = {
     WHERE notes.room_id = ? AND tags.name IN ?
   `,
   getNotes: `
-    SELECT id AS noteId, title, content, created_at as createdAt
+    SELECT id AS noteId, title, created_at as createdAt
     FROM notes
     WHERE room_id = ?
     ORDER BY notes.created_at DESC

--- a/queries/roomQueries.js
+++ b/queries/roomQueries.js
@@ -1,26 +1,14 @@
 const roomQueries = {
-  createRoom:
-    "INSERT INTO rooms (id, owner_id, title, code, member_count) VALUES (?, ?, ?, ?, ?)",
-  increaseRoomMemberCount: `
-    UPDATE rooms
-    SET member_count = member_count + 1
-    WHERE id = ?
-  `,
-  decreaseRoomMembercount: `
-    UPDATE rooms
-    SET member_count = member_count - 1
-    WHERE id = ?
-  `,
+  createRoom: "INSERT INTO rooms (id, title, code) VALUES (?, ?, ?)",
+
   checkCode: "SELECT COUNT(*) AS count FROM rooms WHERE code = ?",
   getIdByCode: "SELECT id FROM rooms WHERE code = ?",
   getRoomById: `
-    SELECT rooms.id as roomId, title, notice, member_count, rooms.created_at, owner_id, name as owner
+    SELECT id as roomId, title, notice, code
     FROM rooms 
-    JOIN users 
-    ON users.id = rooms.owner_id 
     WHERE rooms.id = ?`,
   getRooms: `
-    SELECT rooms.*, members.profile_num, members.alarm, members.created_at as joined_at
+    SELECT rooms.*, members.alarm
     FROM rooms 
     JOIN members 
     ON rooms.id = members.room_id
@@ -35,6 +23,9 @@ const roomQueries = {
     SELECT COUNT(*) AS count
     FROM rooms
     WHERE id = ?
+  `,
+  deleteRoom: `
+    DELETE FROM rooms WHERE id = ?
   `,
 };
 

--- a/queries/scheduleQueries.js
+++ b/queries/scheduleQueries.js
@@ -14,7 +14,7 @@ const scheduleQueries = {
   getTotalAttendances: `
     SELECT COUNT(*) AS totalCount
     FROM schedules
-    WHERE room_id = ? AND is_attendance=1
+    WHERE room_id = ? AND is_attendance=1 AND schedules.date < NOW()
   `,
 };
 

--- a/queries/userQueries.js
+++ b/queries/userQueries.js
@@ -7,6 +7,7 @@ const userQueries = {
   updatePassword: `UPDATE users SET password = ?, salt = ? WHERE id = ?`,
   updateFcmToken: `UPDATE users SET fcm_token = ? WHERE id = ?`,
   deleteFcmToken: `UPDATE users SET fcm_token = NULL WHERE id = ?`,
+  getFCMToken: `SELECT fcm_token FROM users WHERE id = ?`,
   deleteFcmTokenByToken: `UPDATE users SET fcm_token = NULL WHERE fcm_token = ?`,
 };
 

--- a/routes/attendancesRouter.js
+++ b/routes/attendancesRouter.js
@@ -7,7 +7,7 @@ const {
 } = require("../controllers/attendancesController");
 
 attendanceRouter.put(
-  "/:attendanceId",
+  "/:roomId",
   verifyToken,
   authorizeUser,
   updateAttendanceStatus

--- a/routes/linksRouter.js
+++ b/routes/linksRouter.js
@@ -1,10 +1,20 @@
 const express = require("express");
 const linkRouter = express.Router();
 const linkController = require("../controllers/linksController");
-const { verifyToken } = require("../middlewares/auth");
+const { verifyToken, authorizeUser } = require("../middlewares/auth");
 
-linkRouter.post("/:roomId", verifyToken, linkController.createLink); // 자료 등록
-linkRouter.get("/:roomId", verifyToken, linkController.getLinks); // 자료 조회
-linkRouter.delete("/:linkId", verifyToken, linkController.deleteLink); // 자료 삭제
+linkRouter.post(
+  "/:roomId",
+  verifyToken,
+  authorizeUser,
+  linkController.createLink
+); // 자료 등록
+linkRouter.get("/:roomId", verifyToken, authorizeUser, linkController.getLinks); // 자료 조회
+linkRouter.delete(
+  "/:roomId/:linkId",
+  verifyToken,
+  authorizeUser,
+  linkController.deleteLink
+); // 자료 삭제
 
 module.exports = linkRouter;

--- a/routes/notesRouter.js
+++ b/routes/notesRouter.js
@@ -5,12 +5,14 @@ const {
   getNotes,
   updateNote,
   deleteNote,
+  getNoteContent,
 } = require("../controllers/notesController");
 
 const noteRouter = express.Router();
 
 noteRouter.post("/:roomId", verifyToken, authorizeUser, createNote);
 noteRouter.get("/:roomId", verifyToken, authorizeUser, getNotes);
+noteRouter.get("/:roomId/:noteId", verifyToken, authorizeUser, getNoteContent);
 noteRouter.put("/:noteId", verifyToken, authorizeUser, updateNote);
 noteRouter.delete("/:roomId/:noteId", verifyToken, authorizeUser, deleteNote);
 module.exports = noteRouter;

--- a/routes/roomsRouter.js
+++ b/routes/roomsRouter.js
@@ -2,15 +2,14 @@ const express = require("express");
 const { verifyToken, authorizeUser } = require("../middlewares/auth");
 const {
   createRoom,
-  getRoomByCode,
   getRooms,
   updateNotice,
+  getRoom,
 } = require("../controllers/roomsController");
 const roomRouter = express.Router();
 
 roomRouter.post("/", verifyToken, createRoom); // 방 생성
-roomRouter.get("/:roomCode", verifyToken, getRoomByCode); // 코드로 방 조회 성공
 roomRouter.get("/", verifyToken, getRooms); // 가입한 방 조회
 roomRouter.put("/:roomId/notice", verifyToken, authorizeUser, updateNotice); // 공지 등록
-
+roomRouter.get("/:roomId", verifyToken, authorizeUser, getRoom);
 module.exports = roomRouter;

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -6,14 +6,22 @@ const { StatusCodes } = require("http-status-codes");
 
 const createAttendance = async (scheduleId, members) => {
   try {
-    const values = members.map((memberId) => [
-      uuidv4(),
-      scheduleId,
-      memberId,
-      false,
-    ]);
+    const attendanceIds = [];
+    const values = members.map((memberId) => {
+      const id = uuidv4();
+      attendanceIds.push(id);
+      return [id, scheduleId, memberId, false];
+    });
 
-    return await conn.query(attendanceQueries.createAttendances, [values]);
+    const [attendanceResult] = await conn.query(
+      attendanceQueries.createAttendances,
+      [values]
+    );
+
+    return {
+      attendanceIds,
+      attendanceResult,
+    };
   } catch (err) {
     throw err;
   }

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -67,7 +67,7 @@ const getUserAttendances = async (userId, roomId) => {
     const records = attendanceResult.map((record) => ({
       date: record.date.split(" ")[0],
       time: record.date.split(" ")[1],
-      status: record.status,
+      status: record.status === 1,
     }));
 
     return {

--- a/services/linkService.js
+++ b/services/linkService.js
@@ -5,55 +5,30 @@ const { v4: uuidv4 } = require("uuid");
 const { StatusCodes } = require("http-status-codes");
 const CustomError = require("../utils/CustomError");
 
-const checkMemberByRoomId = async (roomId, userId) => {
-  const memberResult = await conn.query(memberQueries.checkMember, [
-    roomId,
-    userId,
-  ]);
-
-  if (memberResult[0][0].count === 0) {
-    throw new CustomError(
-      "해당 스터디에 가입되어 있지 않은 회원입니다.",
-      StatusCodes.FORBIDDEN
-    );
-  }
-};
-
 const createLink = async (roomId, userId, title, link) => {
   try {
-    // 방의 유저인지 확인
-    await checkMemberByRoomId(roomId, userId);
-
     const linkId = uuidv4();
-    await conn.query(linkQueries.createLink, [linkId, roomId, title, link]);
+    const [createResult] = await conn.query(linkQueries.createLink, [
+      linkId,
+      roomId,
+      title,
+      link,
+    ]);
 
-    // 등록 날짜 조회
-    const linkResult = await conn.query(linkQueries.getDate, linkId);
+    if (createResult.affectedRows === 0)
+      throw new CustomError("자료 등록 실패", StatusCodes.BAD_REQUEST);
 
     return {
       message: "자료 등록 성공",
-      links: {
-        id: linkId,
-        title,
-        link,
-        createdAt: linkResult[0][0].created_at,
-      },
     };
   } catch (err) {
     throw err;
   }
 };
 
-const getLinks = async (roomId, userId) => {
+const getLinks = async (roomId) => {
   try {
-    // 방의 유저인지 확인
-    await checkMemberByRoomId(roomId, userId);
-
     const [linkResult] = await conn.query(linkQueries.getLinks, roomId);
-
-    if (linkResult.length === 0) {
-      throw new CustomError("자료가 존재하지 않습니다.", StatusCodes.NOT_FOUND);
-    }
 
     return {
       message: "자료 조회 성공",
@@ -61,7 +36,6 @@ const getLinks = async (roomId, userId) => {
         id: link.id,
         title: link.title,
         link: link.url,
-        createdAt: link.created_at,
       })),
     };
   } catch (err) {
@@ -69,29 +43,23 @@ const getLinks = async (roomId, userId) => {
   }
 };
 
-const deleteLink = async (linkId, userId) => {
+const deleteLink = async (linkId) => {
   try {
-    // 삭제할 링크를 조회하여 roomId 확인
     const [linkResult] = await conn.query(linkQueries.getLinkById, linkId);
 
     if (linkResult.length === 0) {
       throw new CustomError("자료를 찾을 수 없습니다.", StatusCodes.NOT_FOUND);
     }
 
-    const roomId = linkResult[0].room_id;
-
-    // 방의 유저인지 확인
-    await checkMemberByRoomId(roomId, userId);
-
     //자료삭제
     const [deleteResult] = await conn.query(linkQueries.deleteLink, linkId);
 
     if (deleteResult.affectedRows === 0) {
-      throw new CustomError("자료삭제 실패", StatusCodes.NOT_FOUND);
+      throw new CustomError("자료 삭제 실패", StatusCodes.NOT_FOUND);
     }
 
     return {
-      message: "자료삭제 성공",
+      message: "자료 삭제 성공",
     };
   } catch (err) {
     throw err;

--- a/services/noteService.js
+++ b/services/noteService.js
@@ -140,6 +140,19 @@ const getNotes = async (roomId, tags, limit, currentPage) => {
   };
 };
 
+const getNoteContent = async (noteId) => {
+  try {
+    const note = await checkNote(noteId);
+
+    return {
+      message: "노트 조회 성공",
+      content: note.content,
+    };
+  } catch (err) {
+    throw err;
+  }
+};
+
 const updateNote = async (noteId, title, content, tags) => {
   try {
     const note = await checkNote(noteId);
@@ -171,4 +184,10 @@ const deleteNote = async (noteId) => {
   }
 };
 
-module.exports = { createNote, getNotes, updateNote, deleteNote };
+module.exports = {
+  createNote,
+  getNotes,
+  updateNote,
+  deleteNote,
+  getNoteContent,
+};

--- a/services/scheduleService.js
+++ b/services/scheduleService.js
@@ -135,7 +135,7 @@ const getSchedule = async (roomId) => {
       title: schedule.title,
       date: schedule.date.split(" ")[0],
       time: schedule.date.split(" ")[1],
-      isAttendance: schedule.is_attendance,
+      isAttendance: schedule.is_attendance === 1,
     }));
 
     return {

--- a/services/userService.js
+++ b/services/userService.js
@@ -6,6 +6,7 @@ const { hashPassword, comparePassword } = require("../utils/hashedpw");
 const { createAccessToken } = require("../middlewares/auth");
 const CustomError = require("../utils/CustomError");
 const { StatusCodes } = require("http-status-codes");
+const memberQueries = require("../queries/memberQueries");
 
 const join = async (name, email, password) => {
   try {
@@ -109,8 +110,7 @@ const getMyPage = async (userId) => {
     const rooms = roomsResult.map((room) => ({
       roomId: room.id,
       title: room.title,
-      alarm: room.alarm,
-      isOwner: room.owner_id === userId,
+      alarm: room.alarm === 1,
     }));
 
     return {
@@ -146,6 +146,8 @@ const deleteFcmToken = async (userId) => {
   if (deleteResult.affectedRows === 0) {
     throw new CustomError("fcm 토큰 삭제 실패", StatusCodes.BAD_REQUEST);
   }
+
+  await conn.query(memberQueries.getAlarmsOff, userId);
 
   return {
     message: "fcm 토큰 삭제 성공",


### PR DESCRIPTION
## 📝 작업 내용
### 전체적인 API 수정
- 응답 값 수정
- rooms 테이블에서 방장, 멤버 수 컬럼 제거
- 링크 API router에 authorizeUser 미들웨어 추가

### API 추가
- 방 데이터 조회 API
- 노트 내용 조회 API

### 알람 기능 수정
- 방 가입 시 알람 기본값 false로 설정
- 알람 설정 변경 시
  - false > true : 미래 출석 일정에 알람 일정 추가
  - true > false : 예정된 알람 일정 모두 제거
- 출석 일정 삭제 시 알람 일정도 함께 삭제
- fcm 토큰 삭제 요청 시 모든 방의 alarm false로 변경

## ✔️ 리뷰 요구사항 (선택)

