### PR TITLE
[Fix/#85] 전반적인 오류 수정

### DIFF
--- a/controllers/membersController.js
+++ b/controllers/membersController.js
@@ -46,7 +46,9 @@ const updateAlarm = async (req, res) => {
   try {
     const roomId = req.roomId;
     const userId = req.userId;
-    const { alarm } = req.body;
+    let { alarm } = req.body;
+
+    alarm = alarm ? 1 : 0;
 
     const result = await memberService.updateAlarm(userId, roomId, alarm);
 

--- a/controllers/schedulesController.js
+++ b/controllers/schedulesController.js
@@ -4,7 +4,9 @@ const scheduleService = require("../services/scheduleService");
 const createSchedule = async (req, res) => {
   try {
     const roomId = req.roomId;
-    const { title, date, time, isAttendance } = req.body;
+    let { title, date, time, isAttendance } = req.body;
+
+    isAttendance = isAttendance ? 1 : 0;
 
     const result = await scheduleService.createSchedule(
       roomId,

--- a/queries/attendanceQueries.js
+++ b/queries/attendanceQueries.js
@@ -20,7 +20,7 @@ const attendanceQueries = {
     FROM attendances
     JOIN schedules
     ON schedules.id = attendances.schedule_id
-    WHERE attendances.user_id = ? AND schedules.room_id = ? AND schedules.date < NOW()
+    WHERE attendances.user_id = ? AND schedules.room_id = ? AND (addtime(schedules.date, "0:20:0") < NOW() OR status=1)
     ORDER BY date DESC
   `,
 

--- a/queries/scheduleQueries.js
+++ b/queries/scheduleQueries.js
@@ -3,7 +3,8 @@ const scheduleQueries = {
 
   deleteSchedule: `DELETE FROM schedules WHERE id = ?`,
 
-  getSchedule: `SELECT * FROM schedules WHERE id = ?`,
+  getSchedule: `
+    SELECT * FROM schedules WHERE id = ?`,
 
   getSchedulesByRoomId: `SELECT * FROM schedules WHERE room_id = ?`,
 
@@ -12,7 +13,7 @@ const scheduleQueries = {
     FROM attendances
     JOIN schedules
     ON attendances.schedule_id = schedules.id
-    WHERE schedules.room_id = ? AND addtime(schedules.date, "0:20:0") > NOW() AND attendances.user_id = ?
+    WHERE schedules.room_id = ? AND attendances.user_id = ? AND addtime(schedules.date, "0:20:0") > NOW() 
     ORDER BY date ASC LIMIT 1
   `,
 

--- a/services/memberService.js
+++ b/services/memberService.js
@@ -197,22 +197,11 @@ const updateAlarm = async (userId, roomId, alarm) => {
       throw new CustomError("알람 변경 실패", StatusCodes.BAD_REQUEST);
     }
 
-    const [[result]] = await conn.query(memberQueries.getAlarmInfo, [
-      userId,
-      roomId,
-    ]);
-    console.log(`changed alarm info : ${result.alarm}`);
-    if (result.alarm == alarm) {
-      console.log(`alarm changed : room(${roomId}) alarm(${alarm})`);
-    } else {
-      console.log("failed to changing Alarm");
-    }
     return {
       messsage: "알람 변경 성공",
     };
   } catch (err) {
     console.log(err);
-
     throw err;
   }
 };

--- a/services/scheduleService.js
+++ b/services/scheduleService.js
@@ -80,6 +80,13 @@ const createMembersAttendance = async (scheduleId, roomId, title, dateTime) => {
 
 const createSchedule = async (roomId, title, date, time, isAttendance) => {
   try {
+    if (isAttendance && dateTime < new Date()) {
+      console.log();
+      throw new CustomError(
+        "과거 날짜에는 출석 일정을 추가할 수 없습니다.",
+        StatusCodes.BAD_REQUEST
+      );
+    }
     const scheduleId = uuidv4();
     const dateTime = new Date(`${date}T${time}`); // 날짜 + 시간
     const values = [scheduleId, roomId, title, dateTime, isAttendance];
@@ -117,6 +124,12 @@ const deleteSchedule = async (scheduleId) => {
       throw new CustomError("일정을 찾을 수 없습니다.", StatusCodes.NOT_FOUND);
     }
 
+    if (scheduleResult.is_attendance) {
+      throw new CustomError(
+        "과거의 출석 일정은 삭제할 수 없습니다.",
+        StatusCodes.BAD_REQUEST
+      );
+    }
     const [deleteResult] = await conn.query(
       scheduleQueries.deleteSchedule,
       scheduleId

--- a/utils/bodyValidations.js
+++ b/utils/bodyValidations.js
@@ -4,7 +4,6 @@ const createEmailChain = () =>
   body("email")
     .notEmpty()
     .withMessage("email 필드는 공란일 수 없습니다.")
-    .escape()
     .isEmail()
     .withMessage("email 형식이 아닙니다.");
 
@@ -12,7 +11,6 @@ const createDateChain = () =>
   body("date")
     .notEmpty()
     .withMessage("date 필드는 공란일 수 없습니다.")
-    .escape()
     .isDate()
     .withMessage("date 형식이 잘못되었습니다.");
 
@@ -20,7 +18,6 @@ const createTimeChain = () =>
   body("time")
     .notEmpty()
     .withMessage("time 필드는 공란일 수 없습니다.")
-    .escape()
     .isTime({ format: "HH:MM" })
     .withMessage("time 형식이 잘못되었습니다.");
 
@@ -28,7 +25,6 @@ const createStringWithLimitChain = (fieldName, limit) =>
   body(fieldName)
     .notEmpty()
     .withMessage(`${fieldName} 필드는 공란일 수 없습니다.`)
-    .escape()
     .isString()
     .withMessage(`${fieldName} 필드는 string 타입입니다.`)
     .isLength({ max: limit })
@@ -38,7 +34,6 @@ const createStringChain = (fieldName) =>
   body(fieldName)
     .notEmpty()
     .withMessage(`${fieldName} 필드는 공란일 수 없습니다.`)
-    .escape()
     .isString()
     .withMessage(`${fieldName} 필드는 string 타입입니다.`);
 
@@ -46,7 +41,6 @@ const createArrayChain = (fieldName) =>
   body(fieldName)
     .notEmpty()
     .withMessage(`${fieldName} 필드는 공란일 수 없습니다.`)
-    .escape()
     .isArray()
     .withMessage(`${fieldName} 필드는 array 타입입니다.`);
 
@@ -54,7 +48,6 @@ const createBooleanChain = (fieldName) =>
   body(fieldName)
     .notEmpty()
     .withMessage(`${fieldName} 필드는 공란일 수 없습니다.`)
-    .escape()
     .isBoolean()
     .withMessage(`${fieldName} 필드는 boolean 타입입니다.`);
 
@@ -62,7 +55,6 @@ const createIdChain = (fieldName) =>
   body(fieldName)
     .notEmpty()
     .withMessage(`${fieldName} 필드는 공란일 수 없습니다.`)
-    .escape()
     .isString()
     .withMessage(`${fieldName} 필드는 string 타입입니다.`)
     .isLength({ min: 36, max: 36 })

--- a/utils/paramValidations.js
+++ b/utils/paramValidations.js
@@ -3,14 +3,12 @@ const { param, query } = require("express-validator");
 const createIdChain = (paramName, limit) =>
   param(paramName)
     .notEmpty()
-    .escape()
     .isLength({ min: limit, max: limit })
     .withMessage(`${paramName}가 유효하지 않습니다.`);
 
 const createIsAttendanceChain = () =>
   query("isAttendance")
     .optional()
-    .escape()
     .isBoolean()
     .withMessage("isAttendance는 boolean 타입입니다.");
 


### PR DESCRIPTION
## 📝 작업 내용
- 회원 탈퇴해도 채팅 내역 조회 가능하도록 수
- 자료 모음, 노트 보기 오류 수정
  - 유효성 검사에서 escape() 삭제

- 출석 내역 조회 api 수정
  - 현재 출석 중인 일정은 조회되지 않도록 수정
  - 출석하기 누르거나 출석 시간 지나면 조회 가능

- 일정 삭제 api 수정
   - 과거 출석 일정 삭제 불가능하도록 수정

- 일정 등록 api 수정
  - 과거 날짜에 출석 일정 추가 불가능하도록 수정
 
- boolean으로 들어온 요청값들 1, 0으로 변환
  
## ✔️ 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
