### PR TITLE
[Fix/#93] 채팅 내역 조회 및 회원 탈퇴 버그 수정

### DIFF
--- a/queries/userQueries.js
+++ b/queries/userQueries.js
@@ -9,6 +9,10 @@ const userQueries = {
 
   deleteUser: `DELETE FROM users WHERE id = ?`,
 
+  setForeignKeyOff: `SET foreign_key_checks = 0`,
+
+  setForeignKeyOn: `SET foreign_key_checks = 1`,
+
   checkEmail: `SELECT COUNT(*) as count FROM users WHERE email = ?`,
 
   updateFcmToken: `UPDATE users SET fcm_token = ? WHERE id = ?`,

--- a/services/chatService.js
+++ b/services/chatService.js
@@ -27,22 +27,13 @@ const getChats = async (roomId) => {
     for (let chatItem of chatItemsResult[0]) {
       const userId = chatItem.sender;
       const userResult = await conn.query(userQueries.getNameById, userId);
-      chatItem.sender = userResult[0][0].name;
+      chatItem.sender = userResult[0][0]?.name || "알 수 없음";
+      const profileResult = await conn.query(
+        memberQueries.getProfileNumByUserId,
+        [userId, roomId]
+      );
 
-      const [[{ count }]] = await conn.query(memberQueries.checkMember, [
-        roomId,
-        userId,
-      ]);
-
-      if (count) {
-        const [[profileResult]] = await conn.query(
-          memberQueries.getProfileNumByUserId,
-          [userId, roomId]
-        );
-        chatItem.profileNum = profileResult.profile_num;
-      } else {
-        chatItem.profileNum = 0;
-      }
+      chatItem.profileNum = profileResult[0][0]?.profile_num || 7;
     }
 
     return {

--- a/services/userService.js
+++ b/services/userService.js
@@ -71,7 +71,9 @@ const login = async (email, password) => {
 
 const deleteUser = async (userId) => {
   try {
+    await conn.query(userQueries.setForeignKeyOff);
     await conn.query(userQueries.deleteUser, userId);
+    await conn.query(userQueries.setForeignKeyOn);
 
     return {
       message: "회원 탈퇴 성공",


### PR DESCRIPTION
## 📝 작업 내용
- 채팅 내역 조회
  - 스터디 나간 멤버 profileNum 7로 반환
  - 회원 탈퇴한 멤버 name 알 수 없음, profileNum 7로 반환

- 회원 탈퇴
  - chatItems 미삭제로 생기는 외래키 오류를 해결하기 위해 deleteUser 쿼리 전후로 외래키 설정 쿼리 추가

## ✔️ 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
